### PR TITLE
additional policy available

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "chalk": "^4.1.0",
     "fs-extra": "^9.0.1",
     "iso8601-duration": "^1.2.0",
+    "js-yaml": "^3.14.0",
     "jsonata": "^1.8.3",
     "lodash": "^4.17.19",
     "moment": "^2.27.0",

--- a/safeguards/parse.js
+++ b/safeguards/parse.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const YAML = require('js-yaml');
+
+function parse(ctx, filePath, contents) {
+  // Auto-parse JSON
+  if (filePath.endsWith('.json')) {
+    return JSON.parse(contents);
+  } else if (filePath.endsWith('.yml') || filePath.endsWith('.yaml')) {
+    const options = {
+      filename: filePath,
+    };
+    return YAML.load(contents.toString(), options || {});
+  }
+  throw new ctx.sls.classes.Error(
+    `Unrecognized format of "${filePath}". Policies can be provided either via YAML or JSON files`
+  );
+}
+
+module.exports = parse;


### PR DESCRIPTION
As discussed with @medikoo in #4 

Fixes #4 

@medikoo it supports a single `--policy-file` and multiple `--policy-file` (as well as none, of course). I did *not* implement retrofitting the `--policy-file` option to `sls deploy`, as it is another layer and more complex. We always can open another PR to add that in later.

Looking forward to your response.