### PR TITLE
Validate safeguards config

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,28 @@ class ServerlessSafeguardPlugin {
       'before:safeguards:validate:validate': this.doPackage,
       'safeguards:validate:validate': this.doValidate,
     };
+
+    this.sls.configSchemaHandler.defineCustomProperties({
+      properties: {
+        safeguards: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              safeguard: { type: 'string' },
+              title: { type: 'string' },
+              description: { type: 'string' },
+              enforcementLevel: { enum: ['warning', 'error'] },
+              config: {},
+              path: { type: 'string' },
+              stage: { type: ['string', 'array'] },
+            },
+            required: ['safeguard'],
+            additionalProperties: false,
+          },
+        },
+      },
+    });
   }
 
   beforeDeployResources() {


### PR DESCRIPTION
This adds validation of the `custom.safeguards` config. 

However because of https://github.com/serverless/safeguards-plugin/issues/14 and https://github.com/serverless/enterprise-plugin/issues/521 it will not validate the config yet because the enterprise-plugin is currently overriding the `custom.safeguards` validation.