### PR TITLE
chore: Replace `platform-sdk` with `platform-client`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const { runPolicies, loadPolicyFiles } = require('./safeguards');
-const { getApp, getDeployProfiles } = require('@serverless/platform-sdk');
 const chalk = require('chalk');
 const yml = require('yamljs');
+const { ServerlessSDK } = require('@serverless/platform-client');
 
 class ServerlessSafeguardPlugin {
   constructor(sls, options) {
@@ -132,11 +132,8 @@ class ServerlessSafeguardPlugin {
       );
       process.exit(-1);
     }
-    const app = await getApp({
-      tenant: orgName,
-      token: accessKey,
-      app: appName,
-    });
+    const sdk = new ServerlessSDK({ accessKey });
+    const app = await sdk.apps.get({ orgName, appName });
 
     /**
      * The deploymentProfiles object returns {default: ..., stage: {dev:..., prod:... }}
@@ -149,10 +146,7 @@ class ServerlessSafeguardPlugin {
 
     let profiles = [];
     try {
-      profiles = await getDeployProfiles({
-        accessKey,
-        tenant: orgName,
-      });
+      profiles = await sdk.deploymentProfiles.list({ orgName });
     } catch (err) {
       this.sls.cli.log(chalk.red('Failed to get the deployment profile for unknown reason'));
       this.sls.cli.log(err);

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prettify:updated": "pipe-git-updated --ext=css --ext=html --ext=js --ext=json --ext=md --ext=yaml --ext=yml -- prettier --write --ignore-path .eslintignore"
   },
   "dependencies": {
-    "@serverless/platform-sdk": "^2.3.2",
+    "@serverless/platform-client": "^4.2.0",
     "chalk": "^4.1.0",
     "fs-extra": "^9.0.1",
     "iso8601-duration": "^1.2.0",

--- a/safeguards/index.test.js
+++ b/safeguards/index.test.js
@@ -6,9 +6,6 @@ const { cloneDeep } = require('lodash');
 const chalk = require('chalk');
 const { expect } = require('chai');
 
-let getSafeguardsResolution;
-const getSafeguards = async () => getSafeguardsResolution;
-
 const realStdoutWrite = process.stdout.write;
 
 describe('safeguards', () => {
@@ -30,11 +27,6 @@ describe('safeguards', () => {
     });
 
     runPolicies = proxyquire('./', {
-      '@serverless/platform-sdk': {
-        getSafeguards,
-        getAccessKeyForTenant: async () => 'access-key',
-        urls: { frontendUrl: 'https://dashboard.serverless.com/' },
-      },
       'node-dir': {
         readFiles: async () => {},
       },
@@ -99,7 +91,6 @@ describe('safeguards', () => {
     });
 
     it('does nothing when there are no safeguards', async () => {
-      getSafeguardsResolution = [];
       const ctx = cloneDeep(defualtCtx);
       ctx.sls.service.custom.safeguards = false;
       await runPolicies(ctx);


### PR DESCRIPTION
Part of a wider initiative: https://github.com/serverless/enterprise-plugin/issues/464 

There are not automated tests - I didn't add them because it seems like it's a niche functionality at this point and I've tested it manually via CLI on my local env